### PR TITLE
Feature/gutenberg update

### DIFF
--- a/modern-footnotes/modern-footnotes.block-editor.js
+++ b/modern-footnotes/modern-footnotes.block-editor.js
@@ -1,0 +1,42 @@
+/* Copyright 2017-2018 Sean Williams
+    This file is part of Modern Footnotes.
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+( function( wp ) {
+    var ModernFootnotesButton = function( props ) {
+        return wp.element.createElement(
+            wp.editor.RichTextToolbarButton, {
+                icon: wp.element.createElement('span', { 'class': 'modern-footnotes-admin-button' }),
+                title: 'Add a Footnote',
+                onClick: function() {
+                    props.onChange( wp.richText.toggleFormat(
+                        props.value,
+                        { type: 'modern-footnotes/footnote' }
+                    ));
+                },
+                isActive: props.isActive,
+            }
+        );
+    }
+    wp.richText.registerFormatType(
+        'modern-footnotes/footnote', {
+            title: 'Modern Footnote',
+            tagName: 'mfn',
+            className: null,
+            edit: ModernFootnotesButton
+        }
+    );
+} )( window.wp );

--- a/modern-footnotes/modern-footnotes.block-editor.js
+++ b/modern-footnotes/modern-footnotes.block-editor.js
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Sean Williams
+/* Copyright 2017-2019 Sean Williams
     This file is part of Modern Footnotes.
 
     This program is free software; you can redistribute it and/or modify

--- a/modern-footnotes/modern-footnotes.block-editor.min.js
+++ b/modern-footnotes/modern-footnotes.block-editor.min.js
@@ -1,0 +1,18 @@
+/* Copyright 2017-2018 Sean Williams
+    This file is part of Modern Footnotes.
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+!function(t){t.richText.registerFormatType("modern-footnotes/footnote",{title:"Modern Footnote",tagName:"mfn",className:null,edit:function(e){return t.element.createElement(t.editor.RichTextToolbarButton,{icon:t.element.createElement("span",{class:"modern-footnotes-admin-button"}),title:"Add a Footnote",onClick:function(){e.onChange(t.richText.toggleFormat(e.value,{type:"modern-footnotes/footnote"}))},isActive:e.isActive})}})}(window.wp);

--- a/modern-footnotes/modern-footnotes.block-editor.min.js
+++ b/modern-footnotes/modern-footnotes.block-editor.min.js
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Sean Williams
+/* Copyright 2017-2019 Sean Williams
     This file is part of Modern Footnotes.
 
     This program is free software; you can redistribute it and/or modify

--- a/modern-footnotes/modern-footnotes.js
+++ b/modern-footnotes/modern-footnotes.js
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Sean Williams
+/* Copyright 2017-2019 Sean Williams
     This file is part of Modern Footnotes.
 
     This program is free software; you can redistribute it and/or modify

--- a/modern-footnotes/modern-footnotes.mce-button.js
+++ b/modern-footnotes/modern-footnotes.mce-button.js
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Sean Williams
+/* Copyright 2017-2019 Sean Williams
     This file is part of Modern Footnotes.
 
     This program is free software; you can redistribute it and/or modify

--- a/modern-footnotes/modern-footnotes.mce-button.min.js
+++ b/modern-footnotes/modern-footnotes.mce-button.min.js
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Sean Williams
+/* Copyright 2017-2019 Sean Williams
     This file is part of Modern Footnotes.
 
     This program is free software; you can redistribute it and/or modify

--- a/modern-footnotes/modern-footnotes.min.js
+++ b/modern-footnotes/modern-footnotes.min.js
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Sean Williams
+/* Copyright 2017-2019 Sean Williams
     This file is part of Modern Footnotes.
 
     This program is free software; you can redistribute it and/or modify

--- a/modern-footnotes/modern-footnotes.php
+++ b/modern-footnotes/modern-footnotes.php
@@ -32,6 +32,8 @@ function modern_footnotes_func($atts, $content = "") {
 	} else {
 		$display_number = max($modern_footnotes_used_reference_numbers) + 1;
 	}
+  
+  $content = do_shortcode($content); // render out any shortcodes within the contents
 	
   $content = str_replace('<p>','', $content);
   $content = str_replace('</p>','<br /><br />', $content);

--- a/modern-footnotes/modern-footnotes.php
+++ b/modern-footnotes/modern-footnotes.php
@@ -203,36 +203,33 @@ if (is_admin()) { // admin actions
 //
 // Pre-Gutenberg editor
 //
-$modern_footnotes_wp_version_parts = explode(".", $wp_version);
-if ($modern_footnotes_wp_version_parts[0] <= 4) { //WP Major version 4 and earlier does not have Gutenberg
-	function modern_footnotes_add_container_button() {
-		if ( ! current_user_can('edit_posts') && ! current_user_can('edit_pages') )
-			return;
-		if ( get_user_option('rich_editing') == 'true') {
-			add_filter('mce_external_plugins', 'modern_footnotes_add_container_plugin');
-			add_filter('mce_buttons', 'modern_footnotes_register_container_button');
-		}
-	}
-	if (is_admin()) { 
-		add_action('init', 'modern_footnotes_add_container_button');
-		
-		function modern_footnotes_enqueue_admin_scripts() {
-			wp_enqueue_style('modern_footnotes', plugin_dir_url(__FILE__) . 'styles.mce-button.min.css', array(), '1.2.7');
-		}
+function modern_footnotes_add_container_button() {
+  if ( ! current_user_can('edit_posts') && ! current_user_can('edit_pages') )
+    return;
+  if ( get_user_option('rich_editing') == 'true') {
+    add_filter('mce_external_plugins', 'modern_footnotes_add_container_plugin');
+    add_filter('mce_buttons', 'modern_footnotes_register_container_button');
+  }
+}
+if (is_admin()) { 
+  add_filter('init', 'modern_footnotes_add_container_button');
+  
+  function modern_footnotes_enqueue_admin_scripts() {
+    wp_enqueue_style('modern_footnotes', plugin_dir_url(__FILE__) . 'styles.mce-button.min.css', array(), '1.2.7');
+  }
 
-		add_action('admin_enqueue_scripts', 'modern_footnotes_enqueue_admin_scripts'); 
-	}
+  add_action('admin_enqueue_scripts', 'modern_footnotes_enqueue_admin_scripts'); 
+}
 
 
-	function modern_footnotes_register_container_button($buttons) {
-		array_push($buttons, "modern_footnotes");
-		return $buttons;
-	}
+function modern_footnotes_register_container_button($buttons) {
+  array_push($buttons, "modern_footnotes");
+  return $buttons;
+}
 
-	function modern_footnotes_add_container_plugin($plugin_array) {
-		$plugin_array['modern_footnotes'] = plugin_dir_url(__FILE__) . 'modern-footnotes.mce-button.min.js';
-		return $plugin_array;
-	}
+function modern_footnotes_add_container_plugin($plugin_array) {
+  $plugin_array['modern_footnotes'] = plugin_dir_url(__FILE__) . 'modern-footnotes.mce-button.min.js';
+  return $plugin_array;
 }
 //
 // End Pre-Gutenberg editor

--- a/modern-footnotes/modern-footnotes.php
+++ b/modern-footnotes/modern-footnotes.php
@@ -3,7 +3,7 @@
 Plugin Name: Modern Footnotes
 Plugin URI:  http://prismtechstudios.com/modern-footnotes
 Description: Add inline footnotes to your post via the footnote icon on the toolbar for editing posts and pages. Or, use the [mfn] or [modern_footnote] shortcodes [mfn]like this[/mfn].
-Version:     1.2.7
+Version:     1.3.0
 Author:      Prism Tech Studios
 Author URI:  http://prismtechstudios.com/
 License:     GPL2
@@ -71,8 +71,8 @@ add_filter( 'the_content', 'modern_footnotes_replace_mfn_tag_with_shortcode' );
 
 function modern_footnotes_enqueue_scripts() {
 	global $modern_footnotes_options;
-	wp_enqueue_style('modern_footnotes', plugin_dir_url(__FILE__) . 'styles.min.css', array(), '1.2.7');
-	wp_enqueue_script('modern_footnotes', plugin_dir_url(__FILE__) . 'modern-footnotes.min.js', array('jquery'), '1.2.7', TRUE); 
+	wp_enqueue_style('modern_footnotes', plugin_dir_url(__FILE__) . 'styles.min.css', array(), '1.3.0');
+	wp_enqueue_script('modern_footnotes', plugin_dir_url(__FILE__) . 'modern-footnotes.min.js', array('jquery'), '1.3.0', TRUE); 
 	
 	if (!is_admin() && isset($modern_footnotes_options['modern_footnotes_custom_css']) && !empty($modern_footnotes_options['modern_footnotes_custom_css'])) {
 		wp_add_inline_style( 'modern_footnotes', $modern_footnotes_options['modern_footnotes_custom_css'] );
@@ -225,7 +225,7 @@ if (is_admin()) {
   add_filter('init', 'modern_footnotes_add_container_button');
   
   function modern_footnotes_enqueue_admin_scripts() {
-    wp_enqueue_style('modern_footnotes', plugin_dir_url(__FILE__) . 'styles.mce-button.min.css', array(), '1.2.7');
+    wp_enqueue_style('modern_footnotes', plugin_dir_url(__FILE__) . 'styles.mce-button.min.css', array(), '1.3.0');
   }
 
   add_action('admin_enqueue_scripts', 'modern_footnotes_enqueue_admin_scripts'); 
@@ -252,9 +252,9 @@ function modern_footnotes_block_editor_button() {
     wp_enqueue_script( 'modern_footnotes',
         plugin_dir_url(__FILE__) . 'modern-footnotes.block-editor.min.js',
         array( 'wp-rich-text', 'wp-element', 'wp-editor' ),
-        '1.2.7'    
+        '1.3.0'    
     );
-    wp_enqueue_style('modern_footnotes', plugin_dir_url(__FILE__) . 'styles.block-editor-button.min.css', array(), '1.2.7');
+    wp_enqueue_style('modern_footnotes', plugin_dir_url(__FILE__) . 'styles.block-editor-button.min.css', array(), '1.3.0');
 }
 add_action( 'enqueue_block_editor_assets', 'modern_footnotes_block_editor_button' );
 //

--- a/modern-footnotes/modern-footnotes.php
+++ b/modern-footnotes/modern-footnotes.php
@@ -251,12 +251,12 @@ function modern_footnotes_add_container_plugin($plugin_array) {
 // Gutenberg / Block Editor 
 //
 function modern_footnotes_block_editor_button() {
-    wp_enqueue_script( 'modern_footnotes',
+    wp_enqueue_script( 'modern_footnotes_block_editor_js',
         plugin_dir_url(__FILE__) . 'modern-footnotes.block-editor.min.js',
         array( 'wp-rich-text', 'wp-element', 'wp-editor' ),
         '1.3.0'    
     );
-    wp_enqueue_style('modern_footnotes', plugin_dir_url(__FILE__) . 'styles.block-editor-button.min.css', array(), '1.3.0');
+    wp_enqueue_style('modern_footnotes_block_editor_css', plugin_dir_url(__FILE__) . 'styles.block-editor-button.min.css', array(), '1.3.0');
 }
 add_action( 'enqueue_block_editor_assets', 'modern_footnotes_block_editor_button' );
 //

--- a/modern-footnotes/modern-footnotes.php
+++ b/modern-footnotes/modern-footnotes.php
@@ -58,6 +58,16 @@ foreach ($modern_footnotes_shortcodes as $modern_footnote_shortcode) {
 
 add_filter('the_post', 'modern_footnotes_reset_count');
 
+// replace <mfn> HTML tags added by Gutenberg/block editor to [mfn] shortcodes
+
+function modern_footnotes_replace_mfn_tag_with_shortcode( $content ) {
+  $content = str_replace('<mfn>','[mfn]',$content);
+  $content = str_replace('</mfn>','[/mfn]',$content);
+  return $content;
+}
+add_filter( 'the_content', 'modern_footnotes_replace_mfn_tag_with_shortcode' );
+ 
+
 
 function modern_footnotes_enqueue_scripts() {
 	global $modern_footnotes_options;
@@ -233,4 +243,20 @@ function modern_footnotes_add_container_plugin($plugin_array) {
 }
 //
 // End Pre-Gutenberg editor
+//
+
+// 
+// Gutenberg / Block Editor 
+//
+function modern_footnotes_block_editor_button() {
+    wp_enqueue_script( 'modern_footnotes',
+        plugin_dir_url(__FILE__) . 'modern-footnotes.block-editor.min.js',
+        array( 'wp-rich-text', 'wp-element', 'wp-editor' ),
+        '1.2.7'    
+    );
+    wp_enqueue_style('modern_footnotes', plugin_dir_url(__FILE__) . 'styles.block-editor-button.min.css', array(), '1.2.7');
+}
+add_action( 'enqueue_block_editor_assets', 'modern_footnotes_block_editor_button' );
+//
+// End Gutenberg / Block Editor
 //

--- a/modern-footnotes/readme.txt
+++ b/modern-footnotes/readme.txt
@@ -69,4 +69,4 @@ Yes. You can use the Modern Footnotes button in the toolbar of the Block Editor 
 1.2.5 - 11/30/18 - Fixed issue with footnotes causing line breaks.
 1.2.6 - 1/28/19 - Removed footnote shortcodes from rendering in RSS feeds.
 1.2.7 - 1/29/19 - Fixed additional shortcode rendering issue in RSS feeds.
-1.3.0 - 2/19/19 - Fixed problem where Classic Editor button did not appear in WP 5.x. Added Gutenberg button.
+1.3.0 - 2/19/19 - Fixed problem where Classic Editor button did not appear in WP 5.x. Added Gutenberg button. Allow shortcode within footnotes.

--- a/modern-footnotes/readme.txt
+++ b/modern-footnotes/readme.txt
@@ -3,7 +3,7 @@ Contributors: Sean Williams
 Tags: footnotes, citations, inline footnotes, inline citations, mobile-friendly citations, mobile-friendly footnotes
 Requires at least: 4.4.8
 Tested up to: 5.0
-Stable tag: 1.2.7
+Stable tag: 1.3.0
 License: GNU General Public License v2
 License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
 
@@ -46,8 +46,8 @@ If you want to customize the styles, you can do so by overriding the following s
 .modern-footnotes-footnote__note--mobile - The styling for a mobile footnote
 .modern-footnotes-footnote__note--desktop - The styling for a desktop footnote
 
-=Is there support for Gutenberg?=
-You can always use Modern footnotes with the [mfn] shortcode, but there isn't built-in support for a block or toolbar icon in Gutenberg yet. This is on the list of things to add in the future.
+=Is there support for the Block Editor/Gutenberg Editor?=
+Yes. You can use the Modern Footnotes button in the toolbar of the Block Editor to move the selected text into a footnote. However, if you want to customize the reference numbers output by the plugin, you'll have to type out the shortcode instead.
 
 == Screenshots ==
 1. http://prismtechstudios.com/modern-footnotes/modern-footnotes-1.png
@@ -69,3 +69,4 @@ You can always use Modern footnotes with the [mfn] shortcode, but there isn't bu
 1.2.5 - 11/30/18 - Fixed issue with footnotes causing line breaks.
 1.2.6 - 1/28/19 - Removed footnote shortcodes from rendering in RSS feeds.
 1.2.7 - 1/29/19 - Fixed additional shortcode rendering issue in RSS feeds.
+1.3.0 - 2/19/19 - Fixed problem where Classic Editor button did not appear in WP 5.x. Added Gutenberg button.

--- a/modern-footnotes/readme.txt
+++ b/modern-footnotes/readme.txt
@@ -2,7 +2,7 @@
 Contributors: Sean Williams
 Tags: footnotes, citations, inline footnotes, inline citations, mobile-friendly citations, mobile-friendly footnotes
 Requires at least: 4.4.8
-Tested up to: 5.0
+Tested up to: 5.1
 Stable tag: 1.3.0
 License: GNU General Public License v2
 License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html

--- a/modern-footnotes/styles.block-editor-button.min.css
+++ b/modern-footnotes/styles.block-editor-button.min.css
@@ -1,0 +1,3 @@
+.modern-footnotes-admin-button {background: url(mce-button.png) 4px 5px no-repeat !important; display:block;width:30px;height:30px;padding: 5px;}
+mfn::before { content: "footnote";color: #888;font-size: 12px;position: relative;top: -5px;margin-right: 3px;margin-left: 3px; }
+mfn { background: #ccc; } 

--- a/modern-footnotes/styles.css
+++ b/modern-footnotes/styles.css
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Sean Williams
+/* Copyright 2017-2019 Sean Williams
     This file is part of Modern Footnotes.
 
     This program is free software; you can redistribute it and/or modify

--- a/modern-footnotes/styles.min.css
+++ b/modern-footnotes/styles.min.css
@@ -1,4 +1,4 @@
-/* Copyright 2017-2018 Sean Williams
+/* Copyright 2017-2019 Sean Williams
     This file is part of Modern Footnotes.
 
     This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
Fixed problem where Classic Editor button did not appear in WP 5.x. 
Added Gutenberg button. 
Allow shortcode within footnotes.