### PR TITLE
Add custom classes to individual footnotes

### DIFF
--- a/modern-footnotes/modern-footnotes.php
+++ b/modern-footnotes/modern-footnotes.php
@@ -136,6 +136,7 @@ function modern_footnotes_func($atts, $content = "") {
     $additional_classes .= 'modern-footnotes-footnote--hover-on-desktop ';
   }
 
+  // If additional space-seperated classes are provided to an individual footnote using [mfn class="some-class"], they are added to the footnote
   if (isset($atts['class'])) {
     $additional_classes .= $atts['class'].' ';
   }

--- a/modern-footnotes/modern-footnotes.php
+++ b/modern-footnotes/modern-footnotes.php
@@ -131,9 +131,13 @@ function modern_footnotes_func($atts, $content = "") {
         !isset($modern_footnotes_options['desktop_footnote_behavior']) && isset($modern_footnotes_options['use_expandable_footnotes_on_desktop_instead_of_tooltips']) && $modern_footnotes_options['use_expandable_footnotes_on_desktop_instead_of_tooltips']
       )
     ) {
-		$additional_classes = 'modern-footnotes-footnote--expands-on-desktop';
+		$additional_classes .= 'modern-footnotes-footnote--expands-on-desktop ';
 	} else if (isset($modern_footnotes_options['desktop_footnote_behavior']) && $modern_footnotes_options['desktop_footnote_behavior'] == 'tooltip_hover') {
-    $additional_classes = 'modern-footnotes-footnote--hover-on-desktop';
+    $additional_classes .= 'modern-footnotes-footnote--hover-on-desktop ';
+  }
+
+  if (isset($atts['class'])) {
+    $additional_classes .= $atts['class'].' ';
   }
   
   // $scope_id will have a unique value for each post on the page -- this helps handle when a post is 

--- a/modern-footnotes/readme.txt
+++ b/modern-footnotes/readme.txt
@@ -32,6 +32,13 @@ The official GitHub repository is at <a href="https://github.com/seankwilliams/m
 .modern-footnotes-footnote__note--mobile - The styling for a mobile footnote
 .modern-footnotes-footnote__note--desktop - The styling for a desktop footnote
 
+== Shortcode options ==
+You can modify some behaviours or styles of your footnotes by using the following options within our shortcode.
+[mfn referencenumber=3]This footnote will have the number 3[/mfn] 
+[mfn class='my-pretty-class']This footnote will have 'my-pretty-class' as additional class, allowing for custom styling of individual footnotes.[/mfn]
+[mfn referencereset='true']This footnote will reset the footnote counter and therfore receive 1 as its number. Following footnotes will also receive their number according to this new start.[/mfn]
+
+
 == Frequently Asked Questions ==
 =How do I create a footnote?=
 Use a footnote in your post by using the footnote icon in the WordPress editor or by using the shortcode: [mfn]this will be a footnote[/mfn]
@@ -55,6 +62,9 @@ If you want to customize the styles, you can do so by overriding the following s
 .modern-footnotes-footnote__note – Styling that applies to both mobile and desktop footnotes
 .modern-footnotes-footnote__note--mobile - The styling for a mobile footnote
 .modern-footnotes-footnote__note--desktop - The styling for a desktop footnote
+
+Furthermore, if you want to apply different styles to different footnotes, you can add additional classes to each individual footnote by using the `class` option in the shortcode like this:
+[mfn class="my-pretty-class"] [/mfn]
 
 =Is there support for the Block Editor/Gutenberg Editor?=
 Yes. You can use the Modern Footnotes button in the toolbar of the Block Editor to move the selected text into a footnote. However, if you want to customize the reference numbers output by the plugin, you'll have to type out the shortcode instead.


### PR DESCRIPTION
This small change enables users to add space-seperated classes to a
footnote, using the `class` option in the shortcode.
```
[mfn class="custom-class-1 custom-class-2"]
```

This enables the user to, e.g., style different categories of footnotes
differently. However, the footnotes will still receive their number as
it was before and the classes will be ignored for that matter.

This partially implements my suggestion in issue "Add the possibility to use different categories for footnotes #28", without counting different categories seperately.
However, this might give a better user experience anyway, as each
footnote's id will remain unique.