### PR TITLE
change wp-editor package to wp-block-editor package

### DIFF
--- a/modern-footnotes/modern-footnotes.block-editor.js
+++ b/modern-footnotes/modern-footnotes.block-editor.js
@@ -19,7 +19,7 @@
     var { __ } = wp.i18n;
     var ModernFootnotesButton = function( props ) {
         return wp.element.createElement(
-            wp.editor.RichTextToolbarButton, {
+            wp.blockEditor.RichTextToolbarButton, {
                 icon: wp.element.createElement('span', { 'className': 'modern-footnotes-admin-button' }),
                 title: __('Add a Footnote', 'modern-footnotes'),
                 onClick: function() {

--- a/modern-footnotes/modern-footnotes.block-editor.min.js
+++ b/modern-footnotes/modern-footnotes.block-editor.min.js
@@ -15,4 +15,4 @@
     with this program; if not, write to the Free Software Foundation, Inc.,
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
-!function(e){var{__:t}=e.i18n;e.richText.registerFormatType("modern-footnotes/footnote",{title:"Modern Footnote",tagName:"mfn",className:null,edit:function(o){return e.element.createElement(e.editor.RichTextToolbarButton,{icon:e.element.createElement("span",{className:"modern-footnotes-admin-button"}),title:t("Add a Footnote","modern-footnotes"),onClick:function(){o.onChange(e.richText.toggleFormat(o.value,{type:"modern-footnotes/footnote"}))},isActive:o.isActive})}})}(window.wp);
+!function(e){var{__:t}=e.i18n;e.richText.registerFormatType("modern-footnotes/footnote",{title:"Modern Footnote",tagName:"mfn",className:null,edit:function(o){return e.element.createElement(e.blockEditor.RichTextToolbarButton,{icon:e.element.createElement("span",{className:"modern-footnotes-admin-button"}),title:t("Add a Footnote","modern-footnotes"),onClick:function(){o.onChange(e.richText.toggleFormat(o.value,{type:"modern-footnotes/footnote"}))},isActive:o.isActive})}})}(window.wp);

--- a/modern-footnotes/modern-footnotes.php
+++ b/modern-footnotes/modern-footnotes.php
@@ -706,7 +706,7 @@ function modern_footnotes_block_editor_button() {
     global $modern_footnotes_version;
     wp_enqueue_script( 'modern_footnotes_block_editor_js',
         plugin_dir_url(__FILE__) . 'modern-footnotes.block-editor.min.js',
-        array( 'wp-rich-text', 'wp-element', 'wp-editor', 'wp-i18n' ),
+        array( 'wp-rich-text', 'wp-element', 'wp-block-editor', 'wp-i18n' ),
         $modern_footnotes_version
     );
     wp_set_script_translations('modern_footnotes_block_editor_js','modern-footnotes');

--- a/modern-footnotes/modern-footnotes.php
+++ b/modern-footnotes/modern-footnotes.php
@@ -703,6 +703,12 @@ function modern_footnotes_add_container_plugin($plugin_array) {
 // Gutenberg / Block Editor 
 //
 function modern_footnotes_block_editor_button() {
+
+    $currentScreen = get_current_screen();
+    if ($currentScreen->id === "widgets") {
+      return;
+    }
+
     global $modern_footnotes_version;
     wp_enqueue_script( 'modern_footnotes_block_editor_js',
         plugin_dir_url(__FILE__) . 'modern-footnotes.block-editor.min.js',


### PR DESCRIPTION
Since Wordpress 5.2 the gutenberg Block Editor package has reorganized.

If the dependency is not changed you will get an error on the widget page because the wp-editor package is not allowed to be loaded there.

https://make.wordpress.org/core/2019/04/09/the-block-editor-javascript-module-in-5-2/